### PR TITLE
Add --always flag to git describe in case not tag exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ifeq ($(shell basename "$$(which git)"),git)
 ifeq ($(shell git rev-parse --is-inside-work-tree),true)
-VERSION = $(shell git describe --tags --dirty)
+VERSION = $(shell git describe --tags --dirty --always)
 endif
 endif
 


### PR DESCRIPTION
make  CROSS_COMPILE=arm-linux-gnueabi- will fail with "fatal: No names found, cannot describe anything." if there is no tag in the repository.

Log
====
make CROSS_COMPILE=arm-linux-gnueabi-
git describe --tags --dirty > version
fatal: No names found, cannot describe anything.