### PR TITLE
tty: Do raw mode again, but this time with feeling

### DIFF
--- a/tty.c
+++ b/tty.c
@@ -101,6 +101,7 @@ int tty_init(struct tty *ctx, const char *path)
 
     tcgetattr(ctx->fd, &termios);
     cfmakeraw(&termios);
+    tcsetattr(ctx->fd, TCSAFLUSH, &termios);
 
     return ctx->fd;
 }


### PR DESCRIPTION
There seems to be an issue where the '$ ' prompt of the debug console
doesn't immediately appear after supplying the password on the
on (some?) AST2600 (A1?) systems. Write a newline after the password to
force the appearance, which should be compatible with other debug port
implementations.